### PR TITLE
cleans up modal css and clears previous cocktail seraches

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -39,7 +39,7 @@ button.js-modal-trigger {
     font-size: 1.75rem;
     font-weight: bold;
   }
-}
+
 /*Cards*/
 .card-header {
 padding: 1.75rem 0;
@@ -91,12 +91,14 @@ section {
 
 .modal-card-body {
   background-color: #66d7d1;
-  color: #fc7753
+  color: #fc7753;
+  margin-top: -20px;
+  margin-bottom: -22px;
 }
 
 .modal-card-head {
   background-color: #fc7753;
-  color: #fc7753
+  color: #fc7753;
 }
 
 .modal-card-foot {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -103,10 +103,16 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  // Function to close modal
+  // Function to close modal and clear previous search results
   function closeModal(modal) {
-    modal.style.display = 'none';
+    modal.style.display = 'none'; 
+    cocktailItemsDiv.innerHTML = '';
+    mealInfoEl.innerHTML = '';
+  
+
+
   }
+ 
 
   // Add event listeners to all close buttons
   document.querySelectorAll('.modal .delete').forEach(closeButton => {

--- a/index.html
+++ b/index.html
@@ -98,11 +98,11 @@
           <p class="modal-card-title">SIPS</p>
           <button class="delete" aria-label="close"></button>
         </header>
-        <section class="modal-card-body" id="cocktail-recepies"></section>
+        <div class="modal-card-body" id="cocktail-recepies"></section>
 
         <!--Display Favorite Cocktail-->
         <div class="fav-container-Cocktails">
-          <h3>My Favorite Cocktail's</h3>
+          <h3>My Favorite Cocktails</h3>
           <ul class="fav-cocktails" id="fav-cocktails"></ul>
         </div>
 


### PR DESCRIPTION
I connected the top and the bottom of the modals so there's not a clear space in between the header, body and footer.  I also was made changes to js so that the previous search is cleared in the modal. 

Still remaining:
- Previous meal searches still appear when you close the modal and search again
- Close button does not work when you view a favorite sip (this does work for favorite meal). 
<img width="1029" alt="Screenshot 2024-05-23 at 12 15 24 AM" src="https://github.com/tjmcd2010/Supper-and-Sips/assets/164092983/8c64da10-077d-4420-bbaa-c95e0389705d">
